### PR TITLE
Fixed: Generation with nested directories fails on first attempt

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -34,6 +34,8 @@ soft_mkdir() {
 
 status "Rendering site"
 
+mkdir -p $DEST
+
 for file in `find $SRC -name "*.md" -type f` 
 do 
    from="${file##$SRC}" # Strip `src` path from file string


### PR DESCRIPTION
- root cause: if the dest directory doesn't exist, it will fail to create nested directories of webpages (i.e. each post in blog/ won't be created
- fix: make the dest dir before running generator