### PR TITLE
Build script: Now copies over non-mardown files (assets).

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -51,5 +51,5 @@ do
     to="$DEST${file##$SRC}"
     echo "${from##$ROOT} --> ${to##$ROOT}"
     mkdir -p $(dirname $to)
-    cp $from $to
+    cp $from $to || warm "Failed to copy asset $to"
 done

--- a/tools/build
+++ b/tools/build
@@ -5,8 +5,8 @@ DEST=${DEST:-"$ROOT/docs"}
 SRC=${SRC:-"$ROOT/src"}
 HEADER=${HEADER:-"$SRC/header.html"}
 FOOTER=${FOOTER:-"$SRC/footer.html"}
-PANOPTS=${PANOPTS:-"--css $SRC/css/main.css \
---email-obfuscation=javascript -f markdown -t html5 -B $HEADER -A $FOOTER"}
+CSS=${CSS:-"css/main.css"}
+PANOPTS=${PANOPTS:-"--css $CSS --email-obfuscation=javascript -f gfm -t html5 -B $HEADER -A $FOOTER"}
 
 
 RED="\033[91m"
@@ -28,19 +28,28 @@ status() {
     echo "$MAG$1$END"
 }
 
-soft_mkdir() {
-   [ -d $1 ] || mkdir $1 
-}
+mkdir -p $DEST
+
 
 status "Rendering site"
-
-mkdir -p $DEST
 
 for file in `find $SRC -name "*.md" -type f` 
 do 
    from="${file##$SRC}" # Strip `src` path from file string
    to="${from%%md}html"
    echo "$from --> $to"
-   soft_mkdir $(dirname "$DEST$to")
+   mkdir -p $(dirname "$DEST$to")
    pandoc $PANOPTS --output=$DEST$to $file || warn "failed to create $to"
+done
+
+
+status "Copying over assets"
+
+for file in `find $SRC ! -name "*.md" -type f`
+do 
+    from=$file
+    to="$DEST${file##$SRC}"
+    echo "${from##$ROOT} --> ${to##$ROOT}"
+    mkdir -p $(dirname $to)
+    cp $from $to
 done


### PR DESCRIPTION
- Added step to copy assets over
- Added CSS path as an env variable. 
- refactored the script a bit (now using `mkdir -p`). 